### PR TITLE
Fix typo in Player interface

### DIFF
--- a/playable.go
+++ b/playable.go
@@ -8,5 +8,5 @@ type Playable interface {
 
 type Player interface {
 	PlayNote(Note, time.Duration)
-	PlaySequence(Sequence, singleNoteDuration time.Duration)
+	PlaySequence(Sequence, time.Duration)
 }


### PR DESCRIPTION
Go was thinking Sequence was a time.Duration, which is silly.